### PR TITLE
feat: 쿠폰 발급 API 및 이벤트 기반 발급 플로우 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//kafka
+	implementation 'org.springframework.boot:spring-boot-starter-kafka'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper

--- a/src/main/java/com/example/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/coupon/controller/CouponController.java
@@ -1,0 +1,28 @@
+package com.example.coupon.controller;
+
+import com.example.coupon.service.CouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("api/coupons/")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @PostMapping("/{couponId}/issue")
+    public ResponseEntity<?> issue(
+            @PathVariable Long couponId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        couponService.issueCoupon(userDetails.getUsername(), couponId);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/src/main/java/com/example/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/coupon/controller/CouponController.java
@@ -1,6 +1,5 @@
 package com.example.coupon.controller;
 
-import com.example.coupon.repository.UserRepository;
 import com.example.coupon.service.CouponIssueService;
 import com.example.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ public class CouponController {
 
     private final CouponService couponService;
     private final CouponIssueService couponIssueService;
-    private final UserRepository userRepository;
 
     /**
      * 쿠폰 발급 요청
@@ -40,11 +38,8 @@ public class CouponController {
             @PathVariable Long couponId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        Long userId = userRepository.findByUsername(userDetails.getUsername())
-            .orElseThrow(() -> new RuntimeException("User not found"))
-            .getId();
-        
-        couponIssueService.cancelCoupon(couponId, userId);
+        // userDetails.getUsername()은 userId(principal)로 사용
+        couponIssueService.cancelCoupon(couponId, userDetails.getUsername());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/coupon/controller/CouponController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/coupons/")
+@RequestMapping("/api/coupons")
 public class CouponController {
 
     private final CouponService couponService;

--- a/src/main/java/com/example/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/coupon/controller/CouponController.java
@@ -1,22 +1,27 @@
 package com.example.coupon.controller;
 
+import com.example.coupon.repository.UserRepository;
+import com.example.coupon.service.CouponIssueService;
 import com.example.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("api/coupons/")
 public class CouponController {
 
     private final CouponService couponService;
+    private final CouponIssueService couponIssueService;
+    private final UserRepository userRepository;
 
+    /**
+     * 쿠폰 발급 요청
+     * Redis 선차단 후 Kafka로 비동기 처리
+     */
     @PostMapping("/{couponId}/issue")
     public ResponseEntity<?> issue(
             @PathVariable Long couponId,
@@ -24,5 +29,22 @@ public class CouponController {
     ) {
         couponService.issueCoupon(userDetails.getUsername(), couponId);
         return ResponseEntity.accepted().build();
+    }
+
+    /**
+     * 쿠폰 취소
+     * DB에서 삭제하고 Redis count 감소
+     */
+    @DeleteMapping("/{couponId}/cancel")
+    public ResponseEntity<?> cancel(
+            @PathVariable Long couponId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = userRepository.findByUsername(userDetails.getUsername())
+            .orElseThrow(() -> new RuntimeException("User not found"))
+            .getId();
+        
+        couponIssueService.cancelCoupon(couponId, userId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/coupon/docs/000-sample-example.md
+++ b/src/main/java/com/example/coupon/docs/000-sample-example.md
@@ -1,0 +1,50 @@
+# ADR-000: Coupon Issuance Architecture for High Traffic
+
+DATE: 2026-01-XX
+
+## Status
+Accepted
+
+## Decision Drivers
+- 쿠폰 초과 발급은 반드시 방지되어야 함
+- 수만~수십만 동시 요청을 처리해야 함
+- DB 락 기반 접근은 성능 병목 가능성 존재
+- 장애 발생 시에도 시스템 전체가 멈추지 않아야 함
+
+## Context
+쿠폰 발급 이벤트는 특정 시점에 트래픽이 폭발적으로 증가하는 특성을 가진다.
+기존 DB 기반 수량 관리 방식(비관적/낙관적 락)은 대량 동시 요청 환경에서
+성능 저하 및 병목을 유발할 가능성이 높다.
+
+또한 쿠폰 발급 로직은 단일 API 요청 내에서 즉시 처리하기보다,
+비동기 이벤트 기반으로 분리함으로써 시스템 안정성과 확장성을 확보할 필요가 있다.
+
+## Considered Options
+1. DB 비관적 락을 통한 수량 제어
+2. DB 낙관적 락(version column) 기반 수량 제어
+3. Redis atomic counter 기반 수량 제어 + 비동기 처리
+
+## Decision
+Redis의 atomic INCR 연산을 활용하여 쿠폰 발급 요청 수를 제어하고,
+비동기 메시징 시스템(Kafka)을 통해 실제 발급 처리를 수행한다.
+
+DB는 최종 발급 결과를 저장하는 용도로만 사용하며,
+동시성 제어는 DB 외부(Redis)에서 수행한다.
+
+## Consequences
+
+### Pros
+- DB 락 제거로 높은 처리량 확보
+- Redis atomic 연산으로 경합 상태 방지
+- 비동기 처리로 API 응답 지연 최소화
+- 장애 발생 시에도 요청 유입 차단 가능
+
+### Cons / Trade-offs
+- Redis 및 메시징 시스템 운영 복잡도 증가
+- 분산 환경에서 보상 트랜잭션 필요
+- 최종 발급 결과는 eventual consistency를 가짐
+
+## Follow-up Decisions
+- Redis 이중 카운터 전략 도입 여부
+- 메시지 재처리 및 DLQ 적용 여부
+- Idempotency 키를 통한 중복 요청 방지

--- a/src/main/java/com/example/coupon/docs/001-db-lock-strategy.md
+++ b/src/main/java/com/example/coupon/docs/001-db-lock-strategy.md
@@ -1,0 +1,145 @@
+# ADR-001: DB 락 전략 선택 (낙관적 락 vs 비관적 락)
+
+DATE: 2026-01-XX
+
+## Status
+Accepted
+
+## Decision Drivers
+- 대규모 쿠폰 발급 시스템에서 DB 레벨 동시성 제어 필요
+- 쿠폰 초과 발급 방지 (정합성 보장)
+- 높은 처리량 요구사항
+- DB 커넥션 풀 고갈 방지
+
+## Context
+현재 시스템은 Redis + Kafka 비동기 처리 아키텍처를 사용하고 있다.
+Redis에서 사전 필터링을 통해 대부분의 요청을 차단하고,
+Kafka Consumer에서 실제 DB 저장을 수행한다.
+
+이 구조에서 DB 저장 시점에 어떤 락 전략을 사용할지 결정해야 한다.
+
+## Considered Options
+
+### 1. 비관적 락 (Pessimistic Lock)
+- `@Lock(LockModeType.PESSIMISTIC_WRITE)` 사용
+- SELECT ... FOR UPDATE로 락 획득
+- 다른 트랜잭션은 락이 풀릴 때까지 대기
+
+**장점:**
+- 데이터 일관성 보장
+- 동시 수정 충돌 방지
+- 구현 단순
+
+**단점:**
+- 성능 저하: 대량 동시 요청 시 대기 증가
+- 데드락 위험
+- 확장성 제한: DB 커넥션 고갈 가능
+
+### 2. 낙관적 락 (Optimistic Lock)
+- `@Version` 필드 사용
+- UPDATE ... WHERE id=? AND version=? 형태
+- 버전 불일치 시 OptimisticLockException 발생
+
+**장점:**
+- 성능 우수: 락 대기 없음
+- 높은 처리량: 동시 읽기 가능
+- 확장성 좋음
+
+**단점:**
+- 충돌 시 재시도 로직 필요
+- 재시도 로직 복잡도 증가
+- 충돌 빈도가 높으면 성능 저하 가능
+
+## Decision
+**비관적 락을 사용하고, Kafka + Consumer 제한으로 커넥션 풀 보호**
+
+### 이유
+1. **정합성 보장의 확실성**: 비관적 락은 구현이 단순하고 확실한 정합성 보장
+   - 재시도 로직 불필요
+   - 충돌 시 자동으로 순차 처리
+
+2. **Kafka로 커넥션 풀 보호**: 비관적 락의 단점(커넥션 풀 고갈)을 구조적으로 해결
+   - Consumer 개수를 제한하여 동시 DB 트랜잭션 수 제한
+   - 커넥션 풀 허용치 이하로 설정하여 풀 고갈 불가능
+
+3. **Redis로 사전 차단**: 대량 트래픽을 API 레벨에서 차단
+   - countReq로 쓸데없는 요청을 DB까지 가지 않도록 방어
+   - Kafka로 전달되는 메시지는 최대 100개 (LIMIT)
+
+4. **원자성 보장**: 비관적 락으로 확실한 원자성 보장
+   - 락으로 보호하여 동시 수정 충돌 방지
+   - 트랜잭션 단위로 원자성 보장
+
+## Implementation
+
+### 비관적 락 구현 예시
+```java
+@Entity
+@Table(name = "coupon_policy")
+public class CouponPolicy {
+    private int issuedQuantity;  // 현재 발급 수량
+    
+    public boolean canIssue() {
+        return issuedQuantity < totalQuantity;
+    }
+    
+    public void incrementIssuedQuantity() {
+        if (!canIssue()) {
+            throw new CouponSoldOutException();
+        }
+        this.issuedQuantity++;
+    }
+}
+```
+
+### Repository에 비관적 락 메서드 추가
+```java
+public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cp FROM CouponPolicy cp WHERE cp.id = :id")
+    Optional<CouponPolicy> findByIdWithLock(@Param("id") Long id);
+}
+```
+
+### Consumer에서 비관적 락 사용
+```java
+@KafkaListener(topics = "coupon-issue", concurrency = "10") // 최대 10개 동시 처리
+public void consume(CouponIssueEvent event) {
+    // 비관적 락으로 정합성 보장
+    // Consumer 개수가 제한되어 있어 커넥션 풀 고갈 불가능
+    CouponPolicy policy = repository.findByIdWithLock(event.getCouponId())
+        .orElseThrow();
+    
+    if (policy.canIssue()) {
+        policy.incrementIssuedQuantity();
+        repository.save(policy);
+        saveCouponIssue(event);
+        
+        // 실제 발급 성공 시 Redis count 증가
+        redisTemplate.opsForValue()
+            .increment("coupon:" + event.getCouponId() + ":count");
+    } else {
+        throw new CouponSoldOutException();
+    }
+}
+```
+
+## Consequences
+
+### Pros
+- **확실한 정합성 보장**: 비관적 락으로 동시 수정 충돌 방지
+- **구현 단순**: 재시도 로직 불필요
+- **커넥션 풀 보호**: Kafka + Consumer 제한으로 풀 고갈 방지
+- **Redis 사전 차단**: 대량 트래픽을 DB까지 가지 않도록 방어
+
+### Cons / Trade-offs
+- **처리 지연**: 비동기 처리로 인한 지연 발생
+- **Kafka 운영 복잡도**: 메시징 시스템 운영 필요
+- **Consumer 개수 제한**: 커넥션 풀 크기 고려 필요
+- **최종 일관성**: Eventual Consistency (비동기 처리)
+
+## Notes
+- **비관적 락의 단점(커넥션 풀 고갈)을 Kafka + Consumer 제한으로 구조적으로 해결**
+- **Redis countReq는 "게이트" 역할**: 정확한 재고가 아닌 사전 차단용
+- **정합성의 최종 방어선은 DB 비관적 락**: Redis는 성능/커넥션 풀 보호용
+- **Consumer 개수는 커넥션 풀 크기의 50~70% 권장**: 다른 작업을 위한 여유 확보

--- a/src/main/java/com/example/coupon/docs/002-redis-double-counter-strategy.md
+++ b/src/main/java/com/example/coupon/docs/002-redis-double-counter-strategy.md
@@ -1,0 +1,215 @@
+# ADR-002: Redis 이중 카운터 전략 및 커넥션 풀 보호
+
+DATE: 2026-01-XX
+
+## Status
+Accepted
+
+## Decision Drivers
+- DB 커넥션 풀 고갈 방지
+- 대량 트래픽 사전 차단
+- 정합성 보장과 성능의 균형
+- 쿠폰 취소 시 재발급 가능 여부
+
+## Context
+대규모 쿠폰 발급 시스템에서 수만~수십만 동시 요청이 발생할 수 있다.
+모든 요청이 DB까지 도달하면 커넥션 풀 고갈로 시스템이 마비될 수 있다.
+
+또한 비관적 락을 사용하더라도, 커넥션 풀 허용치 이상의 트랜잭션이 동시에 실행되면
+데드락이나 커넥션 풀 고갈이 발생할 수 있다.
+
+## Considered Options
+
+### 1. 단일 카운터 (countReq만 사용)
+- Redis에서 countReq만 증가
+- 발급 가능 여부 판단
+
+**문제점:**
+- 취소 시 재발급 불가능
+- countReq가 절대 상한선이 되어버림
+
+### 2. 이중 카운터 (countReq + count)
+- countReq: 선차감 (요청 시 증가)
+- count: 실제 차감 (발급 성공 시 증가)
+
+**장점:**
+- 역할 분리 가능
+- 취소 시 count만 감소하여 재발급 가능
+
+### 3. 단일 재고 카운터 (stock)
+- Redis에서 stock만 관리
+- DECR로 재고 차감
+
+**장점:**
+- 단순한 구조
+- 취소 시 INCR로 재고 복구
+
+## Decision
+**Redis 이중 카운터 전략 + Kafka를 통한 커넥션 풀 보호**
+
+### 아키텍처
+```
+API 요청 
+  → Redis countReq 증가 (선차단)
+  → Kafka 발행
+  → Consumer (제한된 개수)
+  → DB 비관적 락 (정합성 보장)
+```
+
+### 역할 분리
+
+#### 1. countReq (요청 카운터)
+- **목적**: 앞단 트래픽 차단 및 커넥션 풀 보호
+- **증가 시점**: API 요청 시 (Kafka 발행 전)
+- **감소 시점**: 감소하지 않음 (과거 요청 기록)
+- **용도**: "이 이벤트에 몇 명이 입장 시도했는지" 통계
+
+#### 2. count (실제 발급 카운터) 또는 stock (재고)
+- **목적**: 실제 발급 수량 관리
+- **증가 시점**: Consumer에서 DB 저장 성공 시
+- **감소 시점**: 쿠폰 취소 시
+- **용도**: 재발급 가능 여부 판단
+
+### 핵심 원칙
+1. **countReq는 "게이트" 역할만**: 정확한 재고가 아님
+2. **정합성의 최종 방어선은 DB**: Redis는 성능/커넥션 풀 보호용
+3. **Kafka Consumer 수 제한**: 커넥션 풀 허용치 이하로 설정
+
+## Implementation
+
+### API 레벨 (선차단)
+```java
+public void issueCoupon(String username, Long couponId) {
+    // countReq 증가 (선차감)
+    Long reqCount = redisTemplate.opsForValue()
+        .increment("coupon:" + couponId + ":countReq");
+    
+    if (reqCount > LIMIT) {
+        throw new CouponSoldOutException();
+    }
+    
+    // Kafka 발행 (비동기)
+    CouponIssueEvent event = new CouponIssueEvent(couponId, username);
+    kafkaTemplate.send("coupon-issue", event);
+}
+```
+
+### Consumer 레벨 (정합성 보장)
+```java
+@KafkaListener(topics = "coupon-issue", concurrency = "10") // 최대 10개 동시 처리
+public void consume(CouponIssueEvent event) {
+    // DB 비관적 락으로 정합성 보장
+    // Consumer 개수가 제한되어 있어 커넥션 풀 고갈 불가능
+    CouponPolicy policy = repository.findByIdWithLock(event.getCouponId());
+    
+    if (policy.canIssue()) {
+        policy.incrementIssuedQuantity();
+        repository.save(policy);
+        saveCouponIssue(event);
+        
+        // 실제 발급 성공 시 count 증가
+        redisTemplate.opsForValue()
+            .increment("coupon:" + event.getCouponId() + ":count");
+    } else {
+        throw new CouponSoldOutException();
+    }
+}
+```
+
+### 쿠폰 취소 처리
+```java
+public void cancelCoupon(Long couponId, Long userId) {
+    // 1. DB에서 쿠폰 발급 내역 삭제
+    couponIssueRepository.deleteByCouponIdAndUserId(couponId, userId);
+    
+    // 2. Redis count만 감소 (재고 복구)
+    redisTemplate.opsForValue()
+        .decrement("coupon:" + couponId + ":count");
+    
+    // 3. countReq는 건드리지 않음 (과거 요청 기록이므로)
+}
+```
+
+## 커넥션 풀 보호 전략
+
+### 1. Redis 선차단
+- countReq로 대량 트래픽을 API 레벨에서 차단
+- DB까지 가지 않도록 방어
+
+### 2. Kafka 버퍼링
+- 요청을 큐에 쌓아서 완충
+- API 서버는 즉시 응답 (202 Accepted)
+
+### 3. Consumer 개수 제한
+- `concurrency = "10"` → 최대 10개 동시 DB 트랜잭션
+- 커넥션 풀 허용치(예: 20)보다 낮게 설정
+- 비관적 락을 써도 풀 고갈 불가능
+
+### 4. DB 락 전략
+- Consumer 내부에서 비관적 락 사용
+- 동시 트랜잭션 수가 제한되어 있어 안전
+- 비관적 락을 써도 커넥션 풀 고갈 불가능
+
+## 시나리오 예시
+
+### 정상 케이스
+```
+10,000개 동시 요청
+  → Redis: 100개만 통과 (9,900개 즉시 차단)
+  → Kafka: 100개 메시지
+  → Consumer: 10개 동시 처리
+  → DB: 최대 10개 트랜잭션만 동시 실행
+```
+
+### 취소 케이스
+```
+초기: countReq=100, count=100, LIMIT=100
+사용자 A 취소
+  → count: 99 (감소)
+  → countReq: 100 (그대로)
+  
+새로운 사용자 B 요청
+  → countReq: 101 (증가)
+  → countReq(101) > LIMIT(100) → 차단 ❌
+  
+문제: 재고는 1개 남았는데 새 사용자가 못 들어옴
+```
+
+### 해결 방법
+**옵션 1**: countReq를 "게이트"로만 사용하고, 실제 재고는 stock으로 관리
+```java
+// stock으로 재고 관리
+Long remain = redisTemplate.opsForValue()
+    .decrement("coupon:" + couponId + ":stock");
+if (remain < 0) {
+    redisTemplate.opsForValue().increment("coupon:" + couponId + ":stock");
+    throw new CouponSoldOutException();
+}
+```
+
+**옵션 2**: countReq에 버퍼 허용
+```java
+// LIMIT보다 조금 더 허용 (예: LIMIT * 1.1)
+if (reqCount > LIMIT * 1.1) {
+    throw new CouponSoldOutException();
+}
+// 실제 초과 발급은 DB에서 차단
+```
+
+## Consequences
+
+### Pros
+- 커넥션 풀 고갈 방지
+- 대량 트래픽 사전 차단
+- 정합성과 성능의 균형
+- Kafka로 시스템 안정성 확보
+
+### Cons / Trade-offs
+- Redis와 DB 간 불일치 가능성
+- 주기적 동기화 필요 (보정 작업)
+- 취소 시 재발급 로직 복잡도 증가
+
+## Follow-up Decisions
+- Redis stock 카운터 vs countReq/count 이중 카운터 선택
+- 취소 시 재발급 허용 여부 결정
+- 주기적 동기화 작업 (Scheduler) 구현

--- a/src/main/java/com/example/coupon/docs/003-connection-pool-protection.md
+++ b/src/main/java/com/example/coupon/docs/003-connection-pool-protection.md
@@ -1,0 +1,177 @@
+# ADR-003: Kafka를 통한 DB 커넥션 풀 보호
+
+DATE: 2026-01-XX
+
+## Status
+Accepted
+
+## Decision Drivers
+- DB 커넥션 풀 고갈 방지
+- 비관적 락 사용 시에도 안정적인 동작 보장
+- 대량 트래픽 처리 시 시스템 안정성
+
+## Context
+비관적 락은 DB 커넥션을 "길게 쥐고 있는" 방식이다.
+트랜잭션이 시작되면 락을 획득하고, 커밋/롤백할 때까지 커넥션을 점유한다.
+
+만약 커넥션 풀 허용치(예: 20개)보다 많은 트랜잭션(예: 100개)이 동시에 실행되면:
+- 커넥션 풀 고갈
+- 새로운 요청 처리 불가
+- 시스템 마비
+
+## Problem
+**"DB 커넥션을 길게 쥐는 문제"를 시간적으로 해결하려는 접근:**
+- 락 타임아웃 설정
+- 트랜잭션 시간 단축
+- 락 범위 최소화
+
+**하지만 근본적인 해결책은:**
+- **"애초에 동시에 들어가는 트랜잭션 수를 줄이자"**
+
+## Decision
+**Kafka를 사이에 두어 동시 DB 트랜잭션 수를 제한**
+
+### 아키텍처
+```
+API 요청
+  → Redis countReq (선차단)
+  → Kafka 발행 (비동기 큐)
+  → Consumer (제한된 개수, 예: 10개)
+  → DB 트랜잭션 (비관적/낙관적 락)
+```
+
+### 핵심 원리
+1. **API 서버**: 요청을 Kafka에 밀어넣고 즉시 응답 (202 Accepted)
+   - DB 커넥션을 전혀 사용하지 않음
+   - 빠른 응답 시간
+
+2. **Kafka**: 요청을 큐에 쌓아서 완충(Buffer)
+   - 순차/배치 처리 가능
+   - 시스템 부하 분산
+
+3. **Consumer**: 제한된 개수만 동시 실행
+   - `concurrency = "10"` → 최대 10개 동시 처리
+   - 커넥션 풀 허용치(20)보다 낮게 설정
+   - **비관적 락을 써도 풀 고갈 불가능**
+
+## Implementation
+
+### Consumer 설정
+```java
+@KafkaListener(
+    topics = "coupon-issue",
+    concurrency = "10"  // 최대 10개 동시 처리
+)
+public void consume(CouponIssueEvent event) {
+    // 비관적 락 사용해도 안전
+    // 동시에 최대 10개만 실행되므로 커넥션 풀 고갈 불가능
+    CouponPolicy policy = repository.findByIdWithLock(event.getCouponId());
+    
+    if (policy.canIssue()) {
+        policy.incrementIssuedQuantity();
+        repository.save(policy);
+        saveCouponIssue(event);
+    }
+}
+```
+
+### 커넥션 풀 설정 예시
+```properties
+# application.properties
+spring.datasource.hikari.maximum-pool-size=20
+spring.datasource.hikari.minimum-idle=5
+```
+
+### Consumer 개수 결정
+- **권장**: 커넥션 풀 크기의 50~70%
+- 예: 커넥션 풀 20개 → Consumer 10개
+- 이유: 다른 작업(조회 등)도 커넥션을 사용할 수 있도록 여유 확보
+
+## 시나리오 비교
+
+### Kafka 없이 동기 처리 (문제 상황)
+```
+10,000개 동시 요청
+  → 모두 DB 트랜잭션 시작
+  → 커넥션 풀 20개 초과
+  → 9,980개 요청은 커넥션 대기
+  → 타임아웃 발생
+  → 시스템 마비
+```
+
+### Kafka + Consumer 제한 (해결)
+```
+10,000개 동시 요청
+  → Redis: 100개만 통과
+  → Kafka: 100개 메시지
+  → Consumer: 최대 10개 동시 처리
+  → DB: 최대 10개 트랜잭션만 동시 실행
+  → 커넥션 풀 안전 (20개 중 10개만 사용)
+  → 나머지 90개는 큐에서 대기
+  → 순차 처리
+```
+
+## 장점
+
+### 1. 커넥션 풀 보호
+- 동시 트랜잭션 수를 강제로 제한
+- 풀 고갈 불가능
+
+### 2. 비관적 락 안전 사용
+- 비관적 락을 써도 안전
+- 락 대기 시간이 길어져도 시스템 안정
+
+### 3. 시스템 안정성
+- 대량 트래픽도 큐에 쌓여서 처리
+- 시스템 부하 분산
+
+### 4. 빠른 API 응답
+- API 서버는 즉시 응답 (202 Accepted)
+- 사용자 경험 향상
+
+## Trade-offs
+
+### Pros
+- 커넥션 풀 고갈 방지
+- 비관적 락 안전 사용 가능
+- 시스템 안정성 확보
+- 빠른 API 응답
+
+### Cons
+- 처리 지연 발생 (비동기)
+- Kafka 운영 복잡도 증가
+- 최종 일관성 (Eventual Consistency)
+- 메시지 손실 가능성 (DLQ 처리 필요)
+
+## Best Practices
+
+### 1. Consumer 개수 설정
+- 커넥션 풀 크기의 50~70%
+- 모니터링 후 조정
+
+### 2. 에러 처리
+- 재시도 로직 구현
+- DLQ(Dead Letter Queue) 설정
+- 알림 시스템 연동
+
+### 3. 모니터링
+- Kafka lag 모니터링
+- Consumer 처리 속도 추적
+- 커넥션 풀 사용률 모니터링
+
+### 4. 확장성
+- Consumer 개수 동적 조정 가능
+- 트래픽 증가 시 Consumer 수 증가
+- 하지만 커넥션 풀 크기 고려 필수
+
+## 결론
+**Kafka를 사이에 두는 것은 "DB 커넥션을 길게 쥐는 문제"를 구조적으로 해결하는 최선의 방법이다.**
+
+- 시간적 해결: 락 타임아웃, 트랜잭션 시간 단축
+- 구조적 해결: **Kafka + Consumer 제한** ← 더 근본적
+
+이 구조를 통해:
+- 비관적 락을 안전하게 사용 가능
+- 커넥션 풀 고갈 방지
+- 대량 트래픽 처리 가능
+- 시스템 안정성 확보

--- a/src/main/java/com/example/coupon/dto/CouponIssueEvent.java
+++ b/src/main/java/com/example/coupon/dto/CouponIssueEvent.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponIssueEvent {
     private Long couponId;
     private String username;

--- a/src/main/java/com/example/coupon/dto/CouponIssueEvent.java
+++ b/src/main/java/com/example/coupon/dto/CouponIssueEvent.java
@@ -1,0 +1,11 @@
+package com.example.coupon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CouponIssueEvent {
+    private Long couponId;
+    private String username;
+}

--- a/src/main/java/com/example/coupon/entity/Coupon.java
+++ b/src/main/java/com/example/coupon/entity/Coupon.java
@@ -1,0 +1,31 @@
+package com.example.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Entity
+@Table(name = "coupon")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 쿠폰 이름
+    @Column(nullable = false)
+    private String name;
+
+    // 할인 금액
+    @Column(nullable = false)
+    private int discountAmount;
+
+    // 정책 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", nullable = false)
+    private CouponPolicy policy;
+}

--- a/src/main/java/com/example/coupon/entity/Coupon.java
+++ b/src/main/java/com/example/coupon/entity/Coupon.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 
 @Entity
 @Table(name = "coupon")

--- a/src/main/java/com/example/coupon/entity/CouponIssue.java
+++ b/src/main/java/com/example/coupon/entity/CouponIssue.java
@@ -1,0 +1,46 @@
+package com.example.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "coupon_issue",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "coupon_id"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponIssue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 발급 받은 유저
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 발급된 쿠폰
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    // 발급 시간
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    // 사용 여부
+    @Column(nullable = false)
+    private boolean used = false;
+
+    public void use() {
+        this.used = true;
+    }
+}

--- a/src/main/java/com/example/coupon/entity/CouponIssue.java
+++ b/src/main/java/com/example/coupon/entity/CouponIssue.java
@@ -17,6 +17,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponIssue {
 
+    public CouponIssue(User user, Coupon coupon, LocalDateTime issuedAt) {
+        this.user = user;
+        this.coupon = coupon;
+        this.issuedAt = issuedAt;
+        this.used = false;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/coupon/entity/CouponIssue.java
+++ b/src/main/java/com/example/coupon/entity/CouponIssue.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/example/coupon/entity/CouponPolicy.java
+++ b/src/main/java/com/example/coupon/entity/CouponPolicy.java
@@ -1,0 +1,39 @@
+package com.example.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "coupon_policy")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponPolicy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 총 발급 수량
+    @Column(nullable = false)
+    private int totalQuantity;
+
+    // 발급 시작 시간
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    // 발급 종료 시간
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+
+    // 활성화 여부
+    @Column(nullable = false)
+    private boolean active;
+
+    public boolean isIssuable(LocalDateTime now) {
+        return active && !now.isBefore(startAt) && !now.isAfter(endAt);
+    }
+}

--- a/src/main/java/com/example/coupon/entity/CouponPolicy.java
+++ b/src/main/java/com/example/coupon/entity/CouponPolicy.java
@@ -32,7 +32,28 @@ public class CouponPolicy {
     @Column(nullable = false)
     private boolean active;
 
+    // 현재 발급 수량
+    @Column(nullable = false)
+    private int issuedQuantity = 0;
+
     public boolean isIssuable(LocalDateTime now) {
         return active && !now.isBefore(startAt) && !now.isAfter(endAt);
+    }
+
+    public boolean canIssue() {
+        return issuedQuantity < totalQuantity;
+    }
+
+    public void incrementIssuedQuantity() {
+        if (!canIssue()) {
+            throw new com.example.coupon.exception.CouponSoldOutException();
+        }
+        this.issuedQuantity++;
+    }
+
+    public void decrementIssuedQuantity() {
+        if (this.issuedQuantity > 0) {
+            this.issuedQuantity--;
+        }
     }
 }

--- a/src/main/java/com/example/coupon/entity/CouponPolicy.java
+++ b/src/main/java/com/example/coupon/entity/CouponPolicy.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/example/coupon/exception/CouponSoldOutException.java
+++ b/src/main/java/com/example/coupon/exception/CouponSoldOutException.java
@@ -1,0 +1,7 @@
+package com.example.coupon.exception;
+
+public class CouponSoldOutException extends RuntimeException {
+    public CouponSoldOutException() {
+        super("Coupon is sold out");
+    }
+}

--- a/src/main/java/com/example/coupon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/coupon/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.example.coupon.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CouponSoldOutException.class)
+    public ResponseEntity<?> handleSoldOut(CouponSoldOutException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of(
+                        "status", "SOLD_OUT",
+                        "message", e.getMessage()
+                ));
+    }
+}

--- a/src/main/java/com/example/coupon/repository/CouponIssueRepository.java
+++ b/src/main/java/com/example/coupon/repository/CouponIssueRepository.java
@@ -1,0 +1,22 @@
+package com.example.coupon.repository;
+
+import com.example.coupon.entity.CouponIssue;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CouponIssueRepository extends JpaRepository<CouponIssue, Long> {
+    
+    @Query("SELECT ci FROM CouponIssue ci WHERE ci.user.id = :userId AND ci.coupon.id = :couponId")
+    Optional<CouponIssue> findByUserIdAndCouponId(@Param("userId") Long userId, @Param("couponId") Long couponId);
+    
+    @Modifying
+    @Query("DELETE FROM CouponIssue ci WHERE ci.coupon.id = :couponId AND ci.user.id = :userId")
+    void deleteByCouponIdAndUserId(@Param("couponId") Long couponId, @Param("userId") Long userId);
+    
+    @Query("SELECT COUNT(ci) FROM CouponIssue ci WHERE ci.coupon.id = :couponId")
+    long countByCouponId(@Param("couponId") Long couponId);
+}

--- a/src/main/java/com/example/coupon/repository/CouponPolicyRepository.java
+++ b/src/main/java/com/example/coupon/repository/CouponPolicyRepository.java
@@ -1,0 +1,17 @@
+package com.example.coupon.repository;
+
+import com.example.coupon.entity.CouponPolicy;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, Long> {
+    
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cp FROM CouponPolicy cp WHERE cp.id = :id")
+    Optional<CouponPolicy> findByIdWithLock(@Param("id") Long id);
+}

--- a/src/main/java/com/example/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.example.coupon.repository;
+
+import com.example.coupon.entity.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/com/example/coupon/repository/UserRepository.java
+++ b/src/main/java/com/example/coupon/repository/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUserId(String userId);
     Optional<User> findByUserId(String userId);
-    Optional<User> findByUsername(String userId);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/example/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/example/coupon/service/CouponIssueService.java
@@ -1,0 +1,133 @@
+package com.example.coupon.service;
+
+import com.example.coupon.dto.CouponIssueEvent;
+import com.example.coupon.entity.Coupon;
+import com.example.coupon.entity.CouponIssue;
+import com.example.coupon.entity.CouponPolicy;
+import com.example.coupon.entity.User;
+import com.example.coupon.exception.CouponSoldOutException;
+import com.example.coupon.repository.CouponIssueRepository;
+import com.example.coupon.repository.CouponPolicyRepository;
+import com.example.coupon.repository.CouponRepository;
+import com.example.coupon.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponIssueService {
+
+    private final CouponPolicyRepository couponPolicyRepository;
+    private final CouponRepository couponRepository;
+    private final CouponIssueRepository couponIssueRepository;
+    private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * Kafka Consumer: 쿠폰 발급 처리
+     * 비관적 락으로 정합성 보장
+     * Consumer 개수 제한으로 커넥션 풀 보호
+     */
+    @KafkaListener(topics = "coupon-issue", concurrency = "10")
+    @Transactional
+    public void consume(CouponIssueEvent event) {
+        log.info("Processing coupon issue event. couponId: {}, username: {}", 
+            event.getCouponId(), event.getUsername());
+
+        try {
+            // 쿠폰 조회
+            Coupon coupon = couponRepository.findById(event.getCouponId())
+                .orElseThrow(() -> new RuntimeException("Coupon not found: " + event.getCouponId()));
+
+            // 비관적 락으로 CouponPolicy 조회
+            CouponPolicy policy = couponPolicyRepository.findByIdWithLock(coupon.getPolicy().getId())
+                .orElseThrow(() -> new RuntimeException("CouponPolicy not found: " + coupon.getPolicy().getId()));
+
+            // 발급 가능 여부 확인
+            if (!policy.canIssue()) {
+                log.warn("Coupon sold out. couponId: {}, issuedQuantity: {}, totalQuantity: {}", 
+                    event.getCouponId(), policy.getIssuedQuantity(), policy.getTotalQuantity());
+                throw new CouponSoldOutException();
+            }
+
+            // 사용자 조회
+            User user = userRepository.findByUsername(event.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found: " + event.getUsername()));
+
+            // 중복 발급 확인
+            couponIssueRepository.findByUserIdAndCouponId(user.getId(), event.getCouponId())
+                .ifPresent(ci -> {
+                    log.warn("Coupon already issued. couponId: {}, userId: {}", 
+                        event.getCouponId(), user.getId());
+                    throw new RuntimeException("Coupon already issued");
+                });
+
+            // 발급 수량 증가
+            policy.incrementIssuedQuantity();
+            couponPolicyRepository.save(policy);
+
+            // CouponIssue 생성 및 저장
+            CouponIssue couponIssue = new CouponIssue(user, coupon, LocalDateTime.now());
+            couponIssueRepository.save(couponIssue);
+
+            // 실제 발급 성공 시 Redis count 증가
+            Long count = redisTemplate.opsForValue()
+                .increment("coupon:" + event.getCouponId() + ":count");
+
+            log.info("Coupon issued successfully. couponId: {}, username: {}, count: {}", 
+                event.getCouponId(), event.getUsername(), count);
+
+        } catch (CouponSoldOutException e) {
+            log.error("Failed to issue coupon - sold out. couponId: {}", event.getCouponId());
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to issue coupon. couponId: {}, username: {}", 
+                event.getCouponId(), event.getUsername(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 쿠폰 취소 처리
+     */
+    @Transactional
+    public void cancelCoupon(Long couponId, Long userId) {
+        log.info("Cancelling coupon. couponId: {}, userId: {}", couponId, userId);
+
+        // CouponIssue 조회 및 삭제
+        CouponIssue couponIssue = couponIssueRepository
+            .findByUserIdAndCouponId(userId, couponId)
+            .orElseThrow(() -> new RuntimeException("CouponIssue not found"));
+
+        // 사용된 쿠폰은 취소 불가
+        if (couponIssue.isUsed()) {
+            throw new RuntimeException("Cannot cancel used coupon");
+        }
+
+        // DB에서 삭제
+        couponIssueRepository.delete(couponIssue);
+
+        // Coupon 조회 후 CouponPolicy 발급 수량 감소
+        Coupon coupon = couponRepository.findById(couponId)
+            .orElseThrow(() -> new RuntimeException("Coupon not found"));
+        
+        CouponPolicy policy = couponPolicyRepository.findByIdWithLock(coupon.getPolicy().getId())
+            .orElseThrow(() -> new RuntimeException("CouponPolicy not found"));
+        policy.decrementIssuedQuantity();
+        couponPolicyRepository.save(policy);
+
+        // Redis count 감소 (재고 복구)
+        Long count = redisTemplate.opsForValue()
+            .decrement("coupon:" + couponId + ":count");
+
+        log.info("Coupon cancelled successfully. couponId: {}, userId: {}, remaining count: {}", 
+            couponId, userId, count);
+    }
+}

--- a/src/main/java/com/example/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/example/coupon/service/CouponIssueService.java
@@ -57,8 +57,8 @@ public class CouponIssueService {
                 throw new CouponSoldOutException();
             }
 
-            // 사용자 조회
-            User user = userRepository.findByUsername(event.getUsername())
+            // 사용자 조회 (principal = userId)
+            User user = userRepository.findByUserId(event.getUsername())
                 .orElseThrow(() -> new RuntimeException("User not found: " + event.getUsername()));
 
             // 중복 발급 확인
@@ -98,7 +98,12 @@ public class CouponIssueService {
      * 쿠폰 취소 처리
      */
     @Transactional
-    public void cancelCoupon(Long couponId, Long userId) {
+    public void cancelCoupon(Long couponId, String userIdPrincipal) {
+        // 사용자 조회 (principal = userId)
+        User user = userRepository.findByUserId(userIdPrincipal)
+            .orElseThrow(() -> new RuntimeException("User not found: " + userIdPrincipal));
+
+        Long userId = user.getId();
         log.info("Cancelling coupon. couponId: {}, userId: {}", couponId, userId);
 
         // CouponIssue 조회 및 삭제

--- a/src/main/java/com/example/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/example/coupon/service/CouponIssueService.java
@@ -128,11 +128,15 @@ public class CouponIssueService {
         policy.decrementIssuedQuantity();
         couponPolicyRepository.save(policy);
 
-        // Redis count 감소 (재고 복구)
+        // Redis count 감소 (실제 발급 수 감소)
         Long count = redisTemplate.opsForValue()
             .decrement("coupon:" + couponId + ":count");
 
-        log.info("Coupon cancelled successfully. couponId: {}, userId: {}, remaining count: {}", 
-            couponId, userId, count);
+        // Redis stock 증가 (재고 복구)
+        Long stock = redisTemplate.opsForValue()
+            .increment(String.format("coupon:%d:stock", couponId));
+
+        log.info("Coupon cancelled successfully. couponId: {}, userId: {}, remaining count: {}, restored stock: {}", 
+            couponId, userId, count, stock);
     }
 }

--- a/src/main/java/com/example/coupon/service/CouponService.java
+++ b/src/main/java/com/example/coupon/service/CouponService.java
@@ -1,0 +1,24 @@
+package com.example.coupon.service;
+
+import com.example.coupon.exception.CouponSoldOutException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final int LIMIT = 100;
+
+    public void issueCoupon(String username, Long couponId) {
+        Long reqCount = redisTemplate.opsForValue().increment("coupon:" + couponId + ":countReq"); // Redis INCR
+
+        if (reqCount > LIMIT) {
+            throw new CouponSoldOutException();
+        }
+
+        // TODO : Kafka 발행
+    }
+}

--- a/src/main/java/com/example/coupon/service/CouponService.java
+++ b/src/main/java/com/example/coupon/service/CouponService.java
@@ -1,14 +1,17 @@
 package com.example.coupon.service;
 
+import com.example.coupon.dto.CouponIssueEvent;
 import com.example.coupon.exception.CouponSoldOutException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CouponService {
 
+    private final KafkaTemplate<String, Object> kafkaTemplate;
     private final StringRedisTemplate redisTemplate;
     private static final int LIMIT = 100;
 
@@ -19,6 +22,8 @@ public class CouponService {
             throw new CouponSoldOutException();
         }
 
-        // TODO : Kafka 발행
+        // Kafka 발행
+        CouponIssueEvent event = new CouponIssueEvent(couponId, username);
+        kafkaTemplate.send("coupon-issue", event);
     }
 }

--- a/src/main/java/com/example/coupon/service/CouponService.java
+++ b/src/main/java/com/example/coupon/service/CouponService.java
@@ -1,29 +1,100 @@
 package com.example.coupon.service;
 
 import com.example.coupon.dto.CouponIssueEvent;
+import com.example.coupon.entity.Coupon;
 import com.example.coupon.exception.CouponSoldOutException;
+import com.example.coupon.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponService {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final StringRedisTemplate redisTemplate;
-    private static final int LIMIT = 100;
+    private final CouponRepository couponRepository;
 
+    private static final String COUPON_LIMIT_KEY_PREFIX = "coupon:%d:limit";
+    private static final String COUPON_COUNT_REQ_KEY_PREFIX = "coupon:%d:countReq";
+    private static final String COUPON_COUNT_KEY_PREFIX = "coupon:%d:count";
+
+    /**
+     * 쿠폰 발급 요청
+     * - 쿠폰별 정책(totalQuantity)을 기반으로 Limit을 결정
+     * - Limit은 Redis에 캐싱
+     * - Redis countReq로 선차단 후 Kafka로 비동기 처리
+     */
     public void issueCoupon(String username, Long couponId) {
-        Long reqCount = redisTemplate.opsForValue().increment("coupon:" + couponId + ":countReq"); // Redis INCR
+        int limit = getCouponLimit(couponId);
 
-        if (reqCount > LIMIT) {
+        // countReq 증가 (선차감) - INCR 결과로 제한 초과 여부 판단
+        String countReqKey = String.format(COUPON_COUNT_REQ_KEY_PREFIX, couponId);
+        Long reqCount = redisTemplate.opsForValue().increment(countReqKey);
+
+        if (reqCount != null && reqCount > limit) {
+            log.warn("Coupon request limit exceeded. couponId: {}, reqCount: {}, limit: {}", couponId, reqCount, limit);
             throw new CouponSoldOutException();
         }
 
-        // Kafka 발행
+        // Kafka 발행 (비동기)
         CouponIssueEvent event = new CouponIssueEvent(couponId, username);
         kafkaTemplate.send("coupon-issue", event);
+
+        log.debug("Coupon issue event sent to Kafka. couponId: {}, username: {}", couponId, username);
+    }
+
+    /**
+     * 쿠폰별 발급 한도(limit) 조회
+     * - 우선 Redis에서 조회
+     * - 없으면 DB에서 Coupon → CouponPolicy.totalQuantity 조회 후 Redis에 캐싱
+     */
+    private int getCouponLimit(Long couponId) {
+        String limitKey = String.format(COUPON_LIMIT_KEY_PREFIX, couponId);
+
+        String cachedLimit = redisTemplate.opsForValue().get(limitKey);
+        if (cachedLimit != null) {
+            try {
+                return Integer.parseInt(cachedLimit);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid limit value in Redis. key: {}, value: {}", limitKey, cachedLimit);
+                // 아래에서 DB에서 다시 읽어 리셋
+            }
+        }
+
+        // DB에서 Coupon 조회 후 Policy의 totalQuantity 사용
+        Coupon coupon = couponRepository.findById(couponId)
+            .orElseThrow(() -> new IllegalArgumentException("Coupon not found. id=" + couponId));
+
+        int limit = coupon.getPolicy().getTotalQuantity();
+
+        // Redis에 캐싱 (TTL은 필요에 따라 추가 가능)
+        redisTemplate.opsForValue().set(limitKey, String.valueOf(limit));
+
+        return limit;
+    }
+
+    /**
+     * 쿠폰 취소
+     * DB에서 삭제하고 Redis count만 감소 (countReq는 그대로)
+     */
+    @Transactional
+    public void cancelCoupon(Long couponId, Long userId) {
+        // DB에서 쿠폰 발급 내역 삭제
+        // (실제 구현은 CouponIssueService에서 처리)
+
+        // Redis count만 감소 (재고 복구)
+        String countKey = String.format(COUPON_COUNT_KEY_PREFIX, couponId);
+        Long count = redisTemplate.opsForValue().decrement(countKey);
+
+        log.info("Coupon cancelled. couponId: {}, userId: {}, remaining count: {}",
+            couponId, userId, count);
+
+        // countReq는 건드리지 않음 (과거 요청 기록이므로)
     }
 }

--- a/src/main/java/com/example/coupon/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/coupon/service/CustomUserDetailsService.java
@@ -14,13 +14,15 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) {
+    public UserDetails loadUserByUsername(String loginId) {
+        // loginId는 userId로 사용
         com.example.coupon.entity.User user =
-                userRepository.findByUsername(username)
+                userRepository.findByUserId(loginId)
                         .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getUsername())
+                // Security principal로 userId 사용
+                .username(user.getUserId())
                 .password(user.getPassword())
                 .roles("USER")
                 .build();


### PR DESCRIPTION
## Summary
- 쿠폰 발급을 이벤트 기반(Kafka)으로 분리하여 고트래픽 환경에 대응
- 비관적 락 + Redis 이중 카운터로 초과 발급 방지 및 커넥션 풀 보호
- 쿠폰 발급/취소 API 추가

## Changes
- `CouponPolicy`
  - `issuedQuantity` 필드 추가 및 `canIssue`, `incrementIssuedQuantity`, `decrementIssuedQuantity` 메서드 구현
- `CouponIssue`
  - `User`, `Coupon`, `issuedAt`를 받는 생성자 추가로 도메인 생성 로직 명확화
- Repositories
  - `CouponPolicyRepository`: `findByIdWithLock` 추가(PESSIMISTIC_WRITE)
  - `CouponIssueRepository`: 중복 발급 조회, 발급 내역 삭제, 쿠폰별 발급 수량 카운트 쿼리 추가
  - `CouponRepository`: 기본 JPA 리포지토리 추가
- 서비스 레이어
  - `CouponIssueService`
    - Kafka Consumer로 쿠폰 발급/취소 처리
    - 비관적 락을 사용해 `CouponPolicy` 발급 수량 제어
    - Redis `coupon:{id}:count`에 실제 발급 수량 반영
  - `CouponService`
    - 쿠폰별 `CouponPolicy.totalQuantity`를 Redis에 `coupon:{id}:limit`으로 캐싱
    - Redis `coupon:{id}:countReq`를 활용해 API 레벨에서 선차단 후 Kafka로 발행
    - 취소 시 Redis `coupon:{id}:count` 감소
- 컨트롤러
  - `CouponController`
    - REST 스타일로 변경 (`@RestController`)
    - `POST /api/coupons/{couponId}/issue` : 쿠폰 발급 요청 (Redis 선차단 + Kafka 발행)
    - `DELETE /api/coupons/{couponId}/cancel` : 쿠폰 취소 (발급 내역 삭제 + Redis count 복구)

## How it works
1. 클라이언트가 `POST /api/coupons/{couponId}/issue` 호출
   - `CouponService`에서 Redis `countReq` INCR
   - 쿠폰별 `limit`(= `CouponPolicy.totalQuantity`) 초과 시 즉시 컷
   - 통과 시 `CouponIssueEvent(couponId, username)`를 Kafka 토픽으로 발행
2. `CouponIssueService.consume` (Kafka Consumer)
   - `Coupon` → `CouponPolicy`를 비관적 락으로 조회
   - `canIssue()`로 발급 가능 여부 확인
   - 중복 발급 여부 체크 후 `CouponIssue` 생성 및 저장
   - Redis `coupon:{id}:count` INCR
3. 취소 시 `DELETE /api/coupons/{couponId}/cancel`
   - 해당 유저의 `CouponIssue` 삭제
   - `CouponPolicy.issuedQuantity` 감소
   - Redis `coupon:{id}:count` DECR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자를 위한 쿠폰 발급(POST, 202) 및 취소(DELETE, 200) REST API와 관련 도메인·서비스·비동기 파이프라인(Redis 재고 게이트 + Kafka 발행/소비) 추가
  * 쿠폰 발행 이벤트 DTO 및 발행/취소 비즈니스 흐름 추가

* **버그 수정 / 동작 개선**
  * 품절 시 HTTP 409을 반환하는 전역 예외 처리 도입

* **문서**
  * 고동시성, Redis 이중 카운터, Kafka 비동기 및 DB 커넥션 풀 보호 관련 ADR 문서 추가

* **잡업(Chores)**
  * Kafka 런타임 의존성 및 Zookeeper/Kafka용 docker-compose 구성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->